### PR TITLE
Fix a typo in ComplexReflectionGroup

### DIFF
--- a/src/HasType.jl
+++ b/src/HasType.jl
@@ -221,7 +221,7 @@ function ComplexReflectionGroup(p,q,r)
            end
    elseif r==1 return coxgroup(:A,1)
    else return coxgroup(:B,r) end
-  elseif p==q && r==2 return coxgroup(:I,2,r)
+  elseif p==q && r==2 return coxgroup(:I,2,p)
   end
  t=TypeIrred(Dict(:series=>:ST,:p=>p,:q=>q,:rank=>r))
   r=getchev(t,:GeneratingRoots)


### PR DESCRIPTION
I found this minor typo while wondering why `ComplexReflectionGroup(48, 48, 2)` does not finish.
I compared it to the implementation in Chevie, so I hope it is correct this way.