### PR TITLE
import `generic_decomposition_matrix`

### DIFF
--- a/src/gendec.jl
+++ b/src/gendec.jl
@@ -1,5 +1,6 @@
 # Glue code for using GenericDecMats.jl
 using GenericDecMats 
+import GenericDecMats: generic_decomposition_matrix
 export GenericDecMats, generic_decomposition_matrix, InducedDecompositionMatrix
 
 @GapObj struct ΦDecMat{T}


### PR DESCRIPTION
from GenericDecMats.jl, in order to extend the function. This way, we avoid the warning about different packages exporting this identifier when calling
`using Gapjm; using GenericDecMats; generic_decomposition_matrix("A4d3")`.